### PR TITLE
Add Emacs support

### DIFF
--- a/editor.h
+++ b/editor.h
@@ -64,6 +64,12 @@ editor_command ()
 			strcat(cmd, " --line %d \"$PWD/%s\"");
 			return cmd;
 		}
+		else if(is_named_executable(env, "emacs"))
+		{
+			strcpy(cmd, env);
+			strcat(cmd, " +%d:%d");
+			return cmd;
+		}
 	}
 
 	if(!env)


### PR DESCRIPTION
Emacs [accepts](http://linux.die.net/man/1/emacs) `+line:column`:

```
+number Go to the line specified by number (do not insert  a  space
        between the "+" sign and the number).  This applies only to
        the next file specified.

+line:column
        Go to the specified line and column.
```
