### PR TITLE
Add support for j/k commands

### DIFF
--- a/pls.c
+++ b/pls.c
@@ -298,8 +298,10 @@ read_command ()
 		return quit;
 	case '\t':
 	case CONTROL('N'):
+	case 'j':
 		return next;
 	case CONTROL('P'):
+	case 'k':
 		return prev;
 	case CONTROL('A'):
 		return first;


### PR DESCRIPTION
This PR adds support for <kbd>j</kbd> and <kbd>k</kbd> commands (Vi-like) for navigating the list of matches.

These are convenient since they are supported by many tools (`less`, `vi`, etc) and complement Emacs-like <kbd>c-n</kbd>, <kbd>c-p</kbd> which are already supported.
